### PR TITLE
fix locale testing bug, accepting both old and new canonical locale forms

### DIFF
--- a/t/02_now.t
+++ b/t/02_now.t
@@ -32,5 +32,5 @@ use DateTime::HiRes;
             );
 
     is( $dt->time_zone_long_name, 'Africa/Cairo', "accepted time_zone parameter" );
-    is( $dt->locale->id, 'ar_EG', "accepted locale parameter" );
+    like( $dt->locale->id, qr'ar[_-]EG', "accepted locale parameter" );
 }


### PR DESCRIPTION
- fixes #1
- fixes [rt-bug#109088]

.# Discussion

In v1.00, DateTime::Locale changed the canonical form of locale to use dashes instead of
underscrores (see [1]). This causes a failure within the "t/02_now.t" test, blocking
unforced installs.

refs
[1] https://github.com/autarch/DateTime-Locale/blob/v1.00/Changes#L44
[rt-bug#109088] https://rt.cpan.org/Public/Bug/Display.html?id=109088 @@ https://archive.is/3RccB
